### PR TITLE
Fix 2 problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This tool can parse and dump WeChat chat history on a rooted android phone.
 + python-PIL
 + [PyQuery](https://pypi.python.org/pypi/pyquery/1.2.1)
 + [pysox](https://pypi.python.org/pypi/pysox/0.3.6.alpha)
++ [dill](https://pypi.python.org/pypi/dill)
 + python-csscompressor(optional)
 + adb and rooted android phone connected to PC
 

--- a/lib/res.py
+++ b/lib/res.py
@@ -8,7 +8,7 @@ import glob
 import os
 import re
 # TODO: perhaps we don't need to introduce PIL and numpy. libjpeg might be enough
-import Image
+from PIL import Image
 import cStringIO
 import base64
 import logging


### PR DESCRIPTION
1. dill should be listed in dependencies explicitly, as the scripts require it to work.
2. Image is a sub-module of PIL on most platforms (such as pillow implementation of PIL), invoking `import Image` would cause an import error, it should be `from PIL import Image`