### PR TITLE
Changed the formatting of the generated HTML

### DIFF
--- a/wechat/render.py
+++ b/wechat/render.py
@@ -162,7 +162,7 @@ class HTMLRender(object):
             nowtime = slice[0].createTime
             if idx == 0 or \
                slices[idx - 1][0].createTime.date() != nowtime.date():
-                timestr = nowtime.strftime("%m/%d %H:%M:%S")
+                timestr = nowtime.strftime("%Y-%m-%d %H:%M:%S")
             else:
                 timestr = nowtime.strftime("%H:%M:%S")
             blocks.append(self.time_html.format(time=timestr))

--- a/wechat/static/TP_INDEX.html
+++ b/wechat/static/TP_INDEX.html
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div class="chatScorll" style="position: relative; font-family:initial;">
-        <div id="chat_chatmsglist" class="chatContent" style="position: absolute;">
+        <div id="chat_chatmsglist" class="chatContent">
           {messages}
         </div>
       </div>

--- a/wechat/static/wx.css
+++ b/wechat/static/wx.css
@@ -137,7 +137,7 @@ table {
 /* Elements */
 html,
 body {
-  height: 100%;
+  /* height: 100%; */
   background: #4e5359 repeat 0 0;
   color: #666;
   font: 14px/1.5 Helvetica, Arial, Tahoma;
@@ -1233,7 +1233,7 @@ a.btnSecondary:active {
   box-shadow: 0 2px 6px #313131;
   z-index: 20;
   /*ie hack*/
-  _height: 400px;
+  /* _height: 400px; */
 }
 .chatPanel {
   /*background:#fff;*/
@@ -1242,7 +1242,7 @@ a.btnSecondary:active {
   -webkit-border-radius: 2px 2px 6px 6px;
   -moz-border-radius: 2px 2px 6px 6px;
   border: 1px solid #424448;
-  _height: 400px;
+  /* _height: 400px; */
   overflow: hidden;
 }
 /*çª—ä½“å¤´éƒ¨æ ‡é¢˜*/
@@ -1278,11 +1278,11 @@ a.btnSecondary:active {
 }
 /*ä¼šè¯å†…å®¹çª—ä½“*/
 .chatPanel .chatScorll {
-  height: 100%;
+  /* height: 100%; */
   width: 100%;
   min-height: 200px;
-  overflow: hidden;
-  overflow-y: auto;
+  /* overflow: hidden; */
+  /* overflow-y: auto; */
   /*border-bottom:1px solid #bebebe;*/
   background-color: #EFF3F7;
 }


### PR DESCRIPTION
Changed the formatting of the generated HTML, to not have a scrollable chat style box, but instead a single page of text. It's more easily printable, and searchable. Also added full YYYY-MM-DD date times, because messages can go back years.

I realise this commit is more a matter of opinion, and what the end-usage of the dumped html is.

In my case, I needed "archive" style dumps of WeChat logs, something that could easily be printed and given to other people. The scrolling textbox defeated that. The full date (including year) was also valuable.
