### PR TITLE
find correct avatar.block.xxxxx file (maybe)

### DIFF
--- a/wechat/avatar.py
+++ b/wechat/avatar.py
@@ -34,12 +34,14 @@ class AvatarReader(object):
             return img
 
     def read_bm_block(self, pos):
-        file_idx = 0
+        file_idx = pos >> 32 
         fname = os.path.join(self.avt_dir,
-                'avatar.block.0000' + str(file_idx))
+                'avatar.block.' + '{:05d}'.format(file_idx))
+        # 16 is unknown prefix
+        # 51 = len('xx/xx/user_this-is-md5-of-length-32.png.bm\x00')
+        # file_idx * (2**32) is offset between block files
+        start_pos = pos - file_idx * (2**32) + 16 + 51
         with open(fname, 'rb') as f:
-            start_pos = pos + 16 + 51
-            # 51 = len('xx/xx/user_this-is-md5-of-length-32.png.bm\x00')
             f.seek(start_pos)
             size = (96, 96, 3)
             img = np.zeros(size, dtype='uint8')


### PR DESCRIPTION
I guess the `file_idx` is calculated by `file_idx = pos >> 32`, and file_idx may be large than 9, then the block of avatar could be
```python
file_idx = pos >> 32 
fname = os.path.join(self.avt_dir, 'avatar.block.' + '{:05d}'.format(file_idx)) 
```
Maybe a correct approach, need more tests.