### PR TITLE
Fallback to 'service call' to obtain IMEI

### DIFF
--- a/android-interact.sh
+++ b/android-interact.sh
@@ -28,6 +28,9 @@ if [[ $1 == "uin" ]]; then
 elif [[ $1 == "imei" ]]; then
 	imei=$(adb shell dumpsys iphonesubinfo | $GREP 'Device ID' | $GREP -o '[0-9]+')
 	[[ -n $imei ]] || {
+		imei=$(adb shell service call iphonesubinfo 1 | awk -F "'" '{print $2}' | sed 's/[^0-9A-F]*//g' | tr -d '\n')
+	}
+	[[ -n $imei ]] || {
 		>&2 echo "Failed to get imei. You can try other methods, or report a bug."
 		exit 1
 	}


### PR DESCRIPTION
Uses the solution from http://stackoverflow.com/a/32293148

Tested and works on Android 6.0.1 on Nexus 4.

Fixes #9.