### PR TITLE
Allow android-interact.sh to be run in another directory

### DIFF
--- a/android-interact.sh
+++ b/android-interact.sh
@@ -3,11 +3,11 @@
 # Date: Fri Jun 26 10:38:07 2015 +0800
 # Author: Yuxin Wu <ppwwyyxxc@gmail.com>
 
-source compatibility.sh
-
-PROG_NAME=`$REALPATH "$0"`
+PROG_NAME=`python -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$0"`
 PROG_DIR=`dirname "$PROG_NAME"`
 cd "$PROG_DIR"
+
+source compatibility.sh
 
 # Please check that your path is the same, since this might be different among devices
 RES_DIR="/mnt/sdcard/tencent/MicroMsg"

--- a/compatibility.sh
+++ b/compatibility.sh
@@ -3,16 +3,10 @@
 # $Date: Tue Jun 16 22:23:36 2015 +0800
 # Author: Vury Leo <i[at]vuryleo[dot]com>
 
-realpath() {
-  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
-
 if [ `uname` = 'Darwin' ]; then
-  REALPATH='realpath'
   GREP='grep -E'
   MD5SUM='md5'
 else
-  REALPATH='readlink -f'
   GREP='grep -E'
   MD5SUM='md5sum'
 fi


### PR DESCRIPTION
In order to source `compatibility.sh`, the working directory must be changed to the directory of the script.  But finding the script's directory requires `$REALPATH`, which is defined in `compatibility.sh`.

To break the cycle, the script now makes use of Python's `os.path.realpath`.