### PR TITLE
Add support for new avatar storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install --user --pre pysox
 		If things still don't work, you can try the [password cracker](https://github.com/chg-hou/EnMicroMsg.db-Password-Cracker)
 		to brute-force the password.
 
-+ Copy the WeChat user resource directory `/mnt/sdcard/tencent/MicroMsg/${userid}/{emoji,image2,sfs,video,voice2}` from the phone to the `resource` directory:
++ Copy the WeChat user resource directory `/mnt/sdcard/tencent/MicroMsg/${userid}/{avatar,emoji,image2,sfs,video,voice2}` from the phone to the `resource` directory:
 	+ `./android-interact.sh res`
 	+ You might need to change `RES_DIR` in the script if the default is incorrect on your phone.
 	+ This can take a __very long__ time. Some manual ways to do it faster:
@@ -87,7 +87,7 @@ pip install --user --pre pysox
                 base64 -di | tar xzf -
             ```
 
-		+ What you'll need in the end is a `resource` directory with the following subdir: `emoji,image2,sfs,video,voice2`.
+		+ What you'll need in the end is a `resource` directory with the following subdir: `avatar,emoji,image2,sfs,video,voice2`.
 
 + (Optional) Download the emoji cache from [here](https://github.com/ppwwyyxx/wechat-dump/releases/download/0.1/emoji.cache.tar.bz2)
 	and put it under `resource/emoji`. This will avoid downloading too many emojis during rendering.

--- a/android-interact.sh
+++ b/android-interact.sh
@@ -53,7 +53,7 @@ elif [[ $1 == "db" || $1 == "res" ]]; then
 	if [[ $1 == "res" ]]; then
 		echo "Pulling resources... this might take a long time, because adb sucks..."
 		mkdir -p resource; cd resource
-		for d in image2 voice2 emoji video sfs; do
+		for d in avatar image2 voice2 emoji video sfs; do
 			mkdir -p $d; cd $d
 			adb pull "$RES_DIR/$chooseUser/$d"
 			cd ..

--- a/wechat/avatar.py
+++ b/wechat/avatar.py
@@ -14,12 +14,18 @@ logger = logging.getLogger(__name__)
 
 from common.textutil import ensure_bin_str, md5
 
+
 class AvatarReader(object):
     def __init__(self, avt_dir, avt_db="avatar.index"):
         self.avt_dir = avt_dir
 
+        self.avatar = avt_dir[:avt_dir.find('sfs')]+'avatar' #new storage of head-image,
         self.avt_db = avt_db
-        if self.avt_db is None or not os.path.isfile(self.avt_db):
+        if self.avt_db is not None and os.path.isfile(self.avt_db):
+            self.ava_file_or_path = True
+        elif os.path.isdir(self.avatar):
+            self.ava_file_or_path = False
+        else:
             logger.warn(
                     "Avatar database {} not found. Will not use avatar!".format(avt_db))
             self.avt_db = None
@@ -37,8 +43,12 @@ class AvatarReader(object):
 
         try:
             try:
-                pos, size = self.query_index(filename)
-                return self.read_img(pos, size)
+                if(self.ava_file_or_path):
+                    pos, size = self.query_index(filename)
+                    return self.read_img(pos, size)
+                else:
+                    img_file = os.path.join(self.avatar, filename)
+                    return Image.open(img_file)
             except TypeError:
                 logger.warn("Avatar for {} not found in avatar database.".format(username))
                 return None

--- a/wechat/avatar.py
+++ b/wechat/avatar.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 # -*- coding: UTF-8 -*-
 # File: avatar.py
-# Date: Thu Jun 18 00:02:07 2015 +0800
+# Date: Wed Nov 29 01:33:56 2017 -0800
 # Author: Yuxin Wu <ppwwyyxxc@gmail.com>
 
 from PIL import Image
@@ -19,20 +19,22 @@ class AvatarReader(object):
     def __init__(self, avt_dir, avt_db="avatar.index"):
         self.avt_dir = avt_dir
 
-        self.avatar = avt_dir[:avt_dir.find('sfs')]+'avatar' #new storage of head-image,
+        # new location of avatar, see #50
+        self.avt_dir_new = avt_dir[:avt_dir.find('sfs')] + 'avatar'
         self.avt_db = avt_db
+        self._use_avt = True
         if self.avt_db is not None and os.path.isfile(self.avt_db):
-            self.ava_file_or_path = True
-        elif os.path.isdir(self.avatar):
-            self.ava_file_or_path = False
+            self.ava_use_db = True
+        elif os.path.isdir(self.avt_dir_new):
+            self.ava_use_db = False
         else:
             logger.warn(
                     "Avatar database {} not found. Will not use avatar!".format(avt_db))
-            self.avt_db = None
+            self._use_avt = False
 
     def get_avatar(self, username):
         """ username: `username` field in db.rcontact"""
-        if self.avt_db is None:
+        if not self._use_avt:
             return None
 
         username = ensure_bin_str(username)
@@ -43,12 +45,12 @@ class AvatarReader(object):
 
         try:
             try:
-                if(self.ava_file_or_path):
+                if self.avt_use_db:
                     pos, size = self.query_index(filename)
                     return self.read_img(pos, size)
                 else:
-                    img_file = os.path.join(self.avatar, filename)
-                    if(os.path.exists(img_file)):
+                    img_file = os.path.join(self.avt_dir_new, filename)
+                    if os.path.exists(img_file):
                         return Image.open(img_file)
                     else:
                         return None

--- a/wechat/avatar.py
+++ b/wechat/avatar.py
@@ -48,7 +48,10 @@ class AvatarReader(object):
                     return self.read_img(pos, size)
                 else:
                     img_file = os.path.join(self.avatar, filename)
-                    return Image.open(img_file)
+                    if(os.path.exists(img_file)):
+                        return Image.open(img_file)
+                    else:
+                        return None
             except TypeError:
                 logger.warn("Avatar for {} not found in avatar database.".format(username))
                 return None

--- a/wechat/render.py
+++ b/wechat/render.py
@@ -95,6 +95,10 @@ class HTMLRender(object):
         sender = u'you ' + msg.talker if not msg.isSend else 'me'
         format_dict = {'sender_label': sender,
                        'time': msg.createTime }
+        if(not msg.isSend and msg.is_chatroom()):
+            format_dict['nickname'] = '>\n       <pre align=\'left\'>'+msg.talker_nickname+'</pre'
+        else:
+            format_dict['nickname'] = ' '
         def fallback():
             template = TEMPLATES[TYPE_MSG]
             content = msg.msg_str()

--- a/wechat/static/TP_EMOJI.html
+++ b/wechat/static/TP_EMOJI.html
@@ -2,7 +2,7 @@
   <div class="chatItemContent">
     <span class="avatar"></span>
     <div class="cloud cloudImg">
-      <div class="cloudPannel" title="{time}">
+      <div class="cloudPannel" title="{time}" {nickname}>
         <div class="cloudBody">
           <div class="cloudContent">
             <span class="img_wrap">

--- a/wechat/static/TP_IMG.html
+++ b/wechat/static/TP_IMG.html
@@ -2,7 +2,7 @@
   <div class="chatItemContent">
     <span class="avatar"></span>
     <div class="cloud cloudImg">
-      <div class="cloudPannel" title="{time}">
+      <div class="cloudPannel" title="{time}" {nickname}>
         <div class="cloudBody">
           <div class="cloudContent">
             <span class="img_wrap">

--- a/wechat/static/TP_MSG.html
+++ b/wechat/static/TP_MSG.html
@@ -2,7 +2,7 @@
   <div class="chatItemContent">
     <span class="avatar"></span>
     <div class="cloud cloudText">
-      <div class="cloudPannel" title="{time}">
+       <div class="cloudPannel" title="{time}" {nickname}>
         <div class="cloudBody">
           <div class="cloudContent">
             <pre style="white-space:pre-wrap">{content}</pre>

--- a/wechat/static/TP_SPEAK.html
+++ b/wechat/static/TP_SPEAK.html
@@ -2,7 +2,7 @@
   <div class="chatItemContent">
     <span class="avatar"></span>
     <div class="cloud cloudVoice" onclick="playVoice(event)" style="width:80px">
-      <div class="cloudPannel" title="{time}">
+      <div class="cloudPannel" title="{time}" {nickname}>
         <div class="sendStatus">
           <span class="second">{voice_duration}"</span>
         </div>


### PR DESCRIPTION
In my wechat 6.5.19 , I cannot find  the avatar.index file in directory sfs, but there is a  directory avatar under the "/mnt/sdcard/tencent/MicroMsg/${userid}/", and the head-images store in this directory.
So I modify wechat-dump/wechat/avatar.py for supporting this.
      I modify the Readme and android-interact.sh for copy the directory avatar.

I find that it has reported as bug in issue #45 .

I also want to add support for display the nickname in chatroom , if i find how to dump the html.