### PR TITLE
Improve stability of WS connection with WXGF decoder app

### DIFF
--- a/wechat/render.py
+++ b/wechat/render.py
@@ -183,7 +183,7 @@ class HTMLRender(object):
                 try:
                     title = pq('title')[0].text
                 except Exception as e:
-                    print(e)
+                    logger.warning(e)
                     title = url
                 content = '<a target="_blank" href="{0}">{1}</a>'.format(url, title)
                 format_dict['content'] = content

--- a/wechat/render.py
+++ b/wechat/render.py
@@ -183,7 +183,7 @@ class HTMLRender(object):
                 try:
                     title = pq('title')[0].text
                 except Exception as e:
-                    logger.warning(e)
+                    logger.warning('No title found in LINK message: ' + str(e))
                     title = url
                 content = '<a target="_blank" href="{0}">{1}</a>'.format(url, title)
                 format_dict['content'] = content

--- a/wechat/render.py
+++ b/wechat/render.py
@@ -180,7 +180,11 @@ class HTMLRender(object):
             pq = PyQuery(msg.content_xml_ready)
             url = pq('url').text()
             if url:
-                title = pq('title')[0].text
+                try:
+                    title = pq('title')[0].text
+                except Exception as e:
+                    print(e)
+                    title = url
                 content = '<a target="_blank" href="{0}">{1}</a>'.format(url, title)
                 format_dict['content'] = content
                 return template.format(**format_dict)

--- a/wechat/wxgf.py
+++ b/wechat/wxgf.py
@@ -32,13 +32,13 @@ class WxgfAndroidDecoder:
         try:
             self.ws.send(data, opcode=0x2)
         except BrokenPipeError as e:
-            logger.warning(e)
+            logger.warning(f'Failed to send data to wxgf service. {e}. Reconnecting ..')
             self.ws = create_connection(self.server)
             self.ws.send(data, opcode=0x2)
         try:
             res = self.ws.recv()
         except Exception as e:
-            logger.warning(e)
+            logger.warning(f'Failed to recv data to wxgf service. {e}. Reconnecting ..')
             self.ws = create_connection(self.server)
             self.ws.send(data, opcode=0x2)
             res = self.ws.recv()

--- a/wechat/wxgf.py
+++ b/wechat/wxgf.py
@@ -17,6 +17,7 @@ class WxgfAndroidDecoder:
             if "://" not in server:
                 server = "ws://" + server
             logger.info(f"Connecting to {server} ...")
+            self.server = server
             self.ws = create_connection(server)
 
     def __del__(self):
@@ -28,8 +29,19 @@ class WxgfAndroidDecoder:
 
     def decode(self, data: bytes) -> bytes | None:
         assert data[:4] == WXGF_HEADER, data[:20]
-        self.ws.send(data, opcode=0x2)
-        res = self.ws.recv()
+        try:
+            self.ws.send(data, opcode=0x2)
+        except BrokenPipeError as e:
+            logger.warning(e)
+            self.ws = create_connection(self.server)
+            self.ws.send(data, opcode=0x2)
+        try:
+            res = self.ws.recv()
+        except Exception as e:
+            logger.warning(e)
+            self.ws = create_connection(self.server)
+            self.ws.send(data, opcode=0x2)
+            res = self.ws.recv()
         if res == FAILURE_MESSAGE:
             return None
         return res


### PR DESCRIPTION
When rendering long chats, the script may miss heartbeats because it is busy downloading avatars and emoticons. In that case, remote (the WXGF decoder Android app) may close the WS connection, resulting in "broken pipe" (at send) or "connection closed" (at recv) errors on the computer. This PR fixes that.

This PR also includes a fix for links without a title (which is quite common), allowing the script to continue in that case.