### PR TITLE
Make it compatible with `user` (not `userdebug`) builds

### DIFF
--- a/android-interact.sh
+++ b/android-interact.sh
@@ -7,18 +7,12 @@ cd "$PROG_DIR"
 
 # Please check that your path is the same, since this might be different among devices
 # RES_DIR="/mnt/sdcard/tencent/MicroMsg"  # old version of wechat use this path.
-RES_DIR="/data/data/com.tencent.mm"
-MM_DIR="/data/data/com.tencent.mm"
-
-echo "Starting rooted adb server..."
-adb root
+RES_DIR="/data/data/com.tencent.mm/MicroMsg"
 
 if [[ $1 == "db" || $1 == "res" ]]; then
 	echo "Looking for user dir name..."
-	sleep 1  	# sometimes adb complains: device not found
 	# look for dirname which looks like md5 (32 alpha-numeric chars)
-	userList=$(adb ls $RES_DIR | cut -f 4 -d ' ' | sed 's/[^0-9a-z]//g' \
-		| awk '{if (length() == 32) print}')
+	userList=$(adb shell su -c "ls $RES_DIR" | awk '{if (length() == 32) print}')
 	numUser=$(echo "$userList" | wc -l)
 	# choose the first user.
 	chooseUser=$(echo "$userList" | head -n1)
@@ -35,20 +29,21 @@ if [[ $1 == "db" || $1 == "res" ]]; then
       echo "Pulling resources... "
       for d in avatar image2 voice2 emoji video sfs; do
         echo "Trying to download $RES_DIR/$chooseUser/$d with busybox ..."
-        adb shell "cd $RES_DIR/$chooseUser &&
-                   busybox tar czf - $d 2>/dev/null | busybox base64" |
-            base64 -di | tar xzf -
+        adb shell su -c "busybox tar czf - $RES_DIR/$chooseUser/$d 2>/dev/null |
+			busybox base64" | base64 -di | tar xzf - --strip-components 5
         [[ -d $d ]] && continue
 
         echo "Trying to download $RES_DIR/$chooseUser/$d with tar & base64 ..."
-        adb shell "cd $RES_DIR/$chooseUser &&
-                   tar czf - $d 2>/dev/null | base64" | base64 -di | tar xzf -
+        adb shell su -c "tar czf - $RES_DIR/$chooseUser/$d 2>/dev/null | base64" |
+			base64 -di | tar xzf - --strip-components 5
         [[ -d $d ]] && continue
 
         echo "Trying to download $RES_DIR/$chooseUser/$d with adb pull (slow) ..."
         mkdir -p $d
         (
           cd $d || exit
+		  adb root
+		  sleep 1 # sometimes adb complains: device not found
           adb pull "$RES_DIR/$chooseUser/$d"
         )
 
@@ -60,18 +55,29 @@ if [[ $1 == "db" || $1 == "res" ]]; then
       echo "Total size: $(du -sh | cut -f1)"
     )
 	else
-		echo "Pulling database and avatar index file..."
-		adb pull $MM_DIR/MicroMsg/$chooseUser/EnMicroMsg.db
-		[[ -f EnMicroMsg.db ]] && \
-			echo "Database successfully downloaded to EnMicroMsg.db" || {
-			>&2 echo "Failed to pull database by adb!"
-			exit 1
+	  for f in EnMicroMsg.db sfs/avatar.index; do
+		echo "Trying to download $RES_DIR/$chooseUser/$f with busybox ..."
+		adb shell su -c "busybox tar czf - $RES_DIR/$chooseUser/$f 2>/dev/null |
+			busybox base64" | base64 -di | tar xzf - --strip-components 5
+		[[ -f $f ]] && continue
+
+		echo "Trying to download $RES_DIR/$chooseUser/$f with tar & base64 ..."
+		adb shell su -c "tar czf - $RES_DIR/$chooseUser/$f 2>/dev/null | base64" |
+			base64 -di | tar xzf - --strip-components 5
+		[[ -f $f ]] && continue
+
+		echo "Trying to download $RES_DIR/$chooseUser/$f with adb pull..."
+		adb root
+		sleep 1
+		adb pull $RES_DIR/$chooseUser/$f
+
+		[[ -f $f ]] || {
+			echo "Failed to download $RES_DIR/$chooseUser/$f"
 		}
-		adb pull $MM_DIR/MicroMsg/$chooseUser/sfs/avatar.index
-		[[ -f avatar.index ]] && echo "Avatar index successfully downloaded to avatar.index"
+	  done
+	  echo "Database and avatar index file successfully downloaded"
 	fi
 else
 	echo "Usage: $0 <res|db>"
 	exit 1
 fi
-


### PR DESCRIPTION
The original `android-interact.sh` script uses `adb root` to get elevated for all subsequent operations. That is convenient, but it only works for `userdebug` [build variant](https://source.android.com/docs/setup/build/building).

Sure, we need root access for all this to work, but there are two kinds of rooted phones:
- Stock ROM with patched bootloader -- `user` build variant,
- Custom ROM -- `userdebug` build variant.

The original script only works for the latter. I am using a Pixel 6a with stock ROM rooted by Magisk, and to make it work for me, I'm making the following changes:
- Remove `adb root` from outer scope
- Use `adb shell su -c` for each command to gain access
- If we had to fall back to `adb pull`, run `adb root` just before the pull

It should still work with `userdebug` ROMs but I don't have such devices. Help of testing on custom ROMs are greatly appreciated!