### PR TITLE
Decode WXGF locally with ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If the tool works for you, please take a moment to add your phone/OS to [the wik
 + [sqlcipher](https://github.com/sqlcipher/sqlcipher) >= 4.1
 + sox (command line tools)
 + Silk audio decoder (included; build it with `./third-party/compile_silk.sh`)
++ ffmpeg (optional; to decode WXGF images locally)
 + Other python dependencies: `pip install -r requirements.txt`.
 
 #### Get Necessary Data:
@@ -62,10 +63,12 @@ If the tool works for you, please take a moment to add your phone/OS to [the wik
   	  `busybox tar` is recommended as the Android system's `tar` may choke on long paths.
 	+ In the end, we need a `resource` directory with the following subdir: `avatar,emoji,image2,sfs,video,voice2`.
 
-4. (Optional) Install and start a WXGF decoder server on an android device. Without this, certain WXGF images will not be rendered or will be rendered in low resolution.
-   See [WXGFDecoder](WXGFDecoder) for instructions.
+4. (Optional) Decode WXGF images:
+   * If `ffmpeg`/`ffprobe` are available, WXGF images/emojis are decoded locally when possible.
+   * Otherwise, you can install and start a WXGF decoder server on an android device and pass `--wxgf-server ws://xx.xx.xx.xx:xxxx`.
+     See [WXGFDecoder](WXGFDecoder) for instructions.
 
-4. (Optional) Download the emoji cache from [here](https://github.com/ppwwyyxx/wechat-dump/releases/download/0.1/emoji.cache.tar.bz2)
+5. (Optional) Download the emoji cache from [here](https://github.com/ppwwyyxx/wechat-dump/releases/download/0.1/emoji.cache.tar.bz2)
 	and decompress it under `wechat-dump`. This will avoid downloading too many emojis during rendering.
 
         wget -c https://github.com/ppwwyyxx/wechat-dump/releases/download/0.1/emoji.cache.tar.bz2
@@ -109,7 +112,7 @@ See [here](http://ppwwyyxx.com/static/wechat/example.html) for an example html.
 ### TODO List (help needed!)
 * After chat history migration, some emojis in the `EmojiInfo` table don't have corresponding URLs but only a md5 -
   they are not downloaded by WeChat until the message needs to be displayed. We don't know how to manually download these emojis.
-* Decoding WXGF images using an android app is too complex. Looking for an easier way (e.g. qemu).
+* Verify/improve host-side WXGF decoding coverage.
 * Fix rare unhandled message types: > 10000 and < 0
 * Better user experiences... see `grep 'TODO' wechat -R`
 

--- a/wechat/emoji.py
+++ b/wechat/emoji.py
@@ -137,7 +137,7 @@ class EmojiReader:
                         content = self.wxgf_decoder.decode_with_cache(fname, content)
                         if content is None:
                             if not self.wxgf_decoder.has_server():
-                                logger.warning("wxgf decoder server is not provided. Cannot decode wxgf emojis.")
+                                logger.warning("Cannot decode wxgf emojis. Install ffmpeg+ffprobe or provide a wxgf decoder server with --wxgf-server.")
                             raise ValueError("Failed to decrypt wxgf file.")
                     else:
                         raise ValueError("Decrypted data mismatch md5!")

--- a/wechat/res.py
+++ b/wechat/res.py
@@ -179,7 +179,7 @@ class Resource(object):
             buf = self.wxgf_decoder.decode_with_cache(img_file, None)
             if buf is None:
                 if not self.wxgf_decoder.has_server():
-                    logger.warning("wxgf decoder server is not provided. Cannot decode wxgf images. Please follow instructions to create wxgf decoder server if these images need to be decoded.")
+                    logger.warning("Cannot decode wxgf images. Install ffmpeg+ffprobe or provide a wxgf decoder server with --wxgf-server.")
                 else:
                     logger.error("Failed to decode wxgf file: {}".format(img_file))
                 return None

--- a/wechat/wxgf.py
+++ b/wechat/wxgf.py
@@ -1,12 +1,151 @@
 from websocket import create_connection
 import os
 import logging
+import shutil
+import subprocess
 
 
 logger = logging.getLogger(__name__)
 
 WXGF_HEADER = b'wxgf'
 FAILURE_MESSAGE = b'FAILED'
+
+_HEVC_START_CODE_4 = b"\x00\x00\x00\x01"
+_HEVC_START_CODE_3 = b"\x00\x00\x01"
+
+
+def extract_hevc_bitstream_from_wxgf(data: bytes) -> bytes | None:
+    """Extract Annex-B HEVC bitstream from WXGF container.
+
+    Returns:
+        HEVC bitstream bytes starting with a start-code, or None if unknown format.
+    """
+    if not data.startswith(WXGF_HEADER):
+        return None
+    start = data.find(_HEVC_START_CODE_4)
+    if start < 0:
+        start = data.find(_HEVC_START_CODE_3)
+    if start < 0:
+        return None
+    return data[start:]
+
+
+def _subprocess_run_bytes(cmd: list[str], *, stdin: bytes) -> bytes | None:
+    try:
+        p = subprocess.run(
+            cmd,
+            input=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if p.returncode != 0:
+        logger.debug(
+            "Command failed (%s): rc=%d stderr=%s",
+            " ".join(cmd),
+            p.returncode,
+            p.stderr[:2000].decode("utf-8", errors="replace"),
+        )
+        return None
+    return p.stdout
+
+
+def _ffprobe_count_frames_hevc(hevc: bytes, *, ffprobe: str = "ffprobe") -> int | None:
+    out = _subprocess_run_bytes(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-count_frames",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=nb_read_frames",
+            "-of",
+            "default=nw=1:nk=1",
+            "-f",
+            "hevc",
+            "-i",
+            "pipe:0",
+        ],
+        stdin=hevc,
+    )
+    if out is None:
+        return None
+    try:
+        return int(out.strip().splitlines()[-1])
+    except Exception:
+        return None
+
+
+def decode_wxgf_with_ffmpeg(
+    data: bytes,
+    *,
+    ffmpeg: str = "ffmpeg",
+    ffprobe: str = "ffprobe",
+) -> bytes | None:
+    """Decode WXGF into a standard image/animation using ffmpeg.
+
+    Returns:
+        - PNG bytes for 1-frame WXGF
+        - GIF bytes for multi-frame WXGF
+        - None if decoding fails or ffmpeg/ffprobe is unavailable.
+    """
+    if shutil.which(ffmpeg) is None or shutil.which(ffprobe) is None:
+        return None
+    hevc = extract_hevc_bitstream_from_wxgf(data)
+    if hevc is None:
+        return None
+
+    frames = _ffprobe_count_frames_hevc(hevc, ffprobe=ffprobe)
+    if frames is not None and frames > 1:
+        # Use palettegen/paletteuse for higher-quality gifs.
+        out = _subprocess_run_bytes(
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "hevc",
+                "-i",
+                "pipe:0",
+                "-filter_complex",
+                "[0:v]split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
+                "-loop",
+                "0",
+                "-f",
+                "gif",
+                "-",
+            ],
+            stdin=hevc,
+        )
+        if out is not None:
+            return out
+
+    # Default: decode the first frame to PNG (keeps quality and alpha).
+    return _subprocess_run_bytes(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "hevc",
+            "-i",
+            "pipe:0",
+            "-frames:v",
+            "1",
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "png",
+            "-",
+        ],
+        stdin=hevc,
+    )
 
 
 class WxgfAndroidDecoder:
@@ -62,9 +201,10 @@ class WxgfAndroidDecoder:
             with open(out_fname, 'rb') as f:
                 return f.read()
 
-        if not self.has_server():
-            return None
-        res = self.decode(data)
+        # Prefer host-side decoding via ffmpeg to avoid Android dependencies.
+        res = decode_wxgf_with_ffmpeg(data)
+        if res is None and self.has_server():
+            res = self.decode(data)
 
         if res is not None:
             with open(out_fname, 'wb') as f:


### PR DESCRIPTION
  - Decode WXGF images/emojis locally by extracting embedded HEVC and transcoding via ffmpeg/ffprobe.
  - Keep --wxgf-server as fallback when ffmpeg isn’t available.